### PR TITLE
fix(deps): Pin numpy to version <2.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ kiteconnect
 pandas
 pandas-ta
 requests
+numpy<2.0


### PR DESCRIPTION
The `pandas-ta` library has an incompatibility with `numpy>=2.0`, which causes an `ImportError` during application startup on Render.

This commit adds `numpy<2.0` to `requirements.txt` to force pip to install a compatible version of numpy, resolving the deployment failure.