### PR TITLE
feat: Add x-api-key auth and smarter endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,37 +2,35 @@
 
 This project provides a comprehensive, FastAPI-based backend service to interact with the Zerodha Kite Connect API. It is designed to serve as a robust backend for trading applications, offering a clean, modern API for complex operations like authentication, data fetching, risk calculation, and full order management.
 
-The application is built for easy local setup and is pre-configured for one-click deployment on the Render platform.
+The application is built for easy local setup and is pre-configured for deployment on the Render platform.
 
 ## Features
 
-- **Full Authentication Flow:** Securely exchange a `request_token` for a session `access_token` and check session status.
-- **Advanced Market Data:**
-  - Get real-time quotes for any instrument.
-  - Fetch historical OHLC candle data.
+- **Dual-Layer Authentication:**
+    - **Service-Level:** All protected endpoints are secured by a static `x-api-key` header.
+    - **User-Level:** A simple flow to get a Kite Connect session `access_token`.
+- **Smarter Market Data Endpoints:**
+  - Get real-time quotes for any instrument. **Now supports symbols with or without an exchange prefix (e.g., `INFY` or `NSE:INFY`).**
+  - Fetch historical OHLC candle data. **Now supports instrument tokens or symbol strings, plus interval shorthands (e.g., `5m`, `1h`).**
   - Search for a specific instrument to get its token and details.
 - **Risk & Target Calculation:**
-  - A `/target/calc` endpoint that uses ATR (Average True Range) to calculate realistic stop-loss and target levels for a trade, with configurable multipliers.
+  - A `/target/calc` endpoint that uses ATR to calculate realistic stop-loss and target levels.
   - A `/risk/check` endpoint to calculate cash risk for a potential trade.
 - **Complete Order Management:**
   - Place, modify, and cancel orders using a consistent JSON-based request structure.
-  - Support for MIS and Bracket Orders (BO).
-  - View a list of all recent orders and current open positions.
 - **Webhook Subscriptions:** Subscribe a URL to receive real-time updates on order status changes.
-- **Deployment Ready:** Includes a `render.yaml` for seamless deployment and uses environment variables for secure management of API keys.
-- **Health Check:** A `/health` endpoint for monitoring service uptime and readiness.
+- **Deployment Ready:** Includes a `render.yaml` and uses environment variables for all secrets.
+- **Health Check:** A `/health` endpoint for monitoring service uptime.
 
 ---
 
 ## Local Setup
 
 ### 1. Prerequisites
-
 - Python 3.8+
 - A Zerodha Kite Developer account with an `api_key` and `api_secret`.
 
 ### 2. Installation
-
 ```bash
 git clone <repository_url>
 cd <repository_name>
@@ -40,17 +38,16 @@ pip install -r requirements.txt
 ```
 
 ### 3. Environment Variables
-
-Set the following environment variables with your Kite API credentials:
+Set the following environment variables.
 
 **On macOS/Linux:**
 ```bash
-export KITE_API_KEY='your_api_key'
-export KITE_API_SECRET='your_api_secret'
+export KITE_API_KEY='your_kite_api_key'
+export KITE_API_SECRET='your_kite_api_secret'
+export INTERNAL_API_KEY='a_strong_secret_key_of_your_choice'
 ```
 
 ### 4. Running the Application
-
 ```bash
 uvicorn kite_live_data.main:app --host 0.0.0.0 --port 8000
 ```
@@ -58,34 +55,33 @@ The API and its interactive documentation will be available at `http://localhost
 
 ---
 
-## Authentication Flow
+## API Usage
 
-1.  **Get Login URL:** Call `GET /auth/login_url`. This will return the URL for the Kite Connect login page.
-2.  **Log In:** Open the URL in a browser and log in with your Zerodha credentials.
-3.  **Handle Callback:** After logging in, Kite will redirect you to the callback URL you configured in your Kite App settings. **You must set this URL to point to this API's `/auth/callback` endpoint.** For local testing, this would be `http://localhost:8000/auth/callback`.
-4.  **Session Created:** The `/auth/callback` endpoint automatically exchanges the received `request_token` for an `access_token` and creates a session. Your browser will show a "success" message. You can now use the other API endpoints.
+### API Security
+All endpoints (except for the public `/health` and `/auth/...` routes) are protected. You must include your `INTERNAL_API_KEY` in the `x-api-key` header with every request.
 
-## API Documentation
+Example with `curl`:
+```bash
+curl -X GET "http://localhost:8000/quote?symbol=NSE:INFY" -H "x-api-key: your_strong_secret_key_of_your_choice"
+```
 
-All endpoints are documented via the automatically generated Swagger UI. Once the server is running, visit `http://localhost:8000/docs` to see a full interactive API specification and to test the endpoints.
+### Authentication Flow
+1.  **Get Login URL:** Call `GET /auth/login_url`.
+2.  **Log In:** Open the URL in a browser and log in.
+3.  **Handle Callback:** Kite will redirect you to this API's `/auth/callback` endpoint. You must have this URL (`http://<your_server>/auth/callback`) configured in your Kite App settings.
+4.  **Session Created:** The API will handle the token exchange. You can now use the authenticated endpoints.
 
-### Key Endpoints
-
-- **Auth:** `GET /auth/login_url`, `GET /auth/callback`, `GET /auth/status`
-- **Market Data:** `GET /quote`, `GET /historical`, `GET /instruments`
-- **Risk/Target:** `POST /target/calc`, `POST /risk/check`
-- **Orders:** `POST /place_order`, `POST /modify_order`, `POST /cancel_order`
-- **Positions:** `GET /orders`, `GET /positions`
-- **Webhooks:** `POST /webhook/subscribe`
-- **Monitoring:** `GET /health`
+### API Documentation
+Visit `http://localhost:8000/docs` for a full interactive API specification. The "Authorize" button in the Swagger UI can be used to set the `x-api-key` for all test requests.
 
 ---
 
 ## Deployment on Render
 
-This repository is ready for deployment on Render.
-
 1.  **Push to Git:** Ensure your code is in a GitHub or GitLab repository.
-2.  **Create Blueprint Service:** On the Render dashboard, create a new "Blueprint" service and connect your repository. Render will use the `render.yaml` file automatically.
-3.  **Add Environment Variables:** In your service's "Environment" tab on Render, add your `KITE_API_KEY` and `KITE_API_SECRET`.
-4.  **Deploy.** Render will build and deploy the service. Your API will be available at the URL provided by Render.
+2.  **Create Blueprint Service:** On the Render dashboard, create a new "Blueprint" service and connect your repository. Render will use `render.yaml` automatically.
+3.  **Add Environment Variables:** In your service's "Environment" tab on Render, add your secrets:
+    -   `KITE_API_KEY`
+    -   `KITE_API_SECRET`
+    -   `INTERNAL_API_KEY` (Choose a strong, random string for this)
+4.  **Deploy.** Your API will be available at the URL provided by Render.

--- a/kite_live_data/main.py
+++ b/kite_live_data/main.py
@@ -1,4 +1,5 @@
-from fastapi import FastAPI, HTTPException, Depends, BackgroundTasks
+from fastapi import FastAPI, HTTPException, Depends, BackgroundTasks, Security
+from fastapi.security import APIKeyHeader
 from fastapi.responses import HTMLResponse
 from pydantic import BaseModel, HttpUrl
 import logging
@@ -19,12 +20,16 @@ app = FastAPI(
     version="1.0.0"
 )
 
-# --- Kite Connect Client ---
-api_key = os.environ.get("KITE_API_KEY")
-api_secret = os.environ.get("KITE_API_SECRET")
-if not api_key or not api_secret:
-    raise RuntimeError("KITE_API_KEY and KITE_API_SECRET environment variables must be set.")
-kite = KiteConnect(api_key=api_key)
+# --- API Keys & Secrets ---
+KITE_API_KEY = os.environ.get("KITE_API_KEY")
+KITE_API_SECRET = os.environ.get("KITE_API_SECRET")
+INTERNAL_API_KEY = os.environ.get("INTERNAL_API_KEY")
+
+if not KITE_API_KEY or not KITE_API_SECRET: raise RuntimeError("KITE_API_KEY and KITE_API_SECRET must be set.")
+if not INTERNAL_API_KEY: raise RuntimeError("INTERNAL_API_KEY for API security must be set.")
+
+kite = KiteConnect(api_key=KITE_API_KEY)
+api_key_header = APIKeyHeader(name="x-api-key", auto_error=True)
 
 # --- In-memory storage ---
 session = {"access_token": None, "expires_at": None, "user_id": None}
@@ -57,15 +62,20 @@ class Position(BaseModel): symbol: str; qty: int; avg_price: float; pnl: float
 class RiskCheckRequest(BaseModel): entry: float; stop_loss: float; quantity: int
 class RiskCheckResponse(BaseModel): cash_risk: float; margin_required: float; rr_ratio: float | None = None
 
+# --- Security & Dependencies ---
+async def verify_api_key(api_key: str = Security(api_key_header)):
+    if api_key != INTERNAL_API_KEY:
+        raise HTTPException(status_code=401, detail="Invalid or missing API Key")
+
+def check_kite_auth():
+    is_connected = session.get("access_token") and session.get("expires_at") and session["expires_at"] > datetime.datetime.now()
+    if not is_connected: raise HTTPException(status_code=401, detail="Kite session not authenticated.")
+    kite.set_access_token(session["access_token"])
+
 # --- Helper Functions ---
 def get_token_expiry_time() -> datetime.datetime:
     now = datetime.datetime.now()
     return (now + datetime.timedelta(days=1)).replace(hour=6, minute=0, second=0, microsecond=0)
-
-def check_auth():
-    is_connected = session.get("access_token") and session.get("expires_at") and session["expires_at"] > datetime.datetime.now()
-    if not is_connected: raise HTTPException(status_code=401, detail="Not authenticated.")
-    kite.set_access_token(session["access_token"])
 
 def send_webhook_update(payload: dict):
     for url in webhook_subscriptions.values():
@@ -118,37 +128,69 @@ def auth_callback(request_token: str):
     except Exception as e:
         return f"""<html><body><h1>Authentication Failed</h1><p>Error: {e}</p></body></html>"""
 
-@app.get("/auth/status", response_model=AuthStatusResponse)
+@app.get("/auth/status", response_model=AuthStatusResponse, dependencies=[Depends(verify_api_key)])
 def get_auth_status():
     is_connected = session.get("access_token") and session.get("expires_at") and session["expires_at"] > datetime.datetime.now()
     return {"connected": is_connected, "expires_at": session.get("expires_at")}
 
-@app.post("/webhook/subscribe", response_model=WebhookResponse)
-def subscribe_webhook(request: WebhookRequest, auth: None = Depends(check_auth)):
+@app.post("/webhook/subscribe", response_model=WebhookResponse, dependencies=[Depends(verify_api_key)])
+def subscribe_webhook(request: WebhookRequest, auth: None = Depends(check_kite_auth)):
     webhook_id = str(uuid.uuid4())
     webhook_subscriptions[webhook_id] = request.url
     return {"ok": True, "webhook_id": webhook_id}
 
-@app.get("/quote", response_model=QuoteResponse)
-def get_quote(symbol: str, auth: None = Depends(check_auth)):
-    try:
-        quote_data = kite.quote(symbol)
-        instrument_quote = quote_data.get(symbol)
-        if not instrument_quote: raise HTTPException(status_code=404, detail="Quote not found")
-        return QuoteResponse(symbol=symbol, **instrument_quote)
-    except Exception as e: raise HTTPException(status_code=500, detail=str(e))
+@app.get("/quote", response_model=QuoteResponse, dependencies=[Depends(verify_api_key)])
+def get_quote(symbol: str, auth: None = Depends(check_kite_auth)):
+    """
+    Gets a quote for a given symbol. If exchange is not specified, defaults to NSE.
+    """
+    formatted_symbol = symbol
+    if ":" not in symbol:
+        # If no exchange is specified, default to NSE.
+        # A more robust implementation might search for the instrument first.
+        formatted_symbol = f"NSE:{symbol.upper()}"
 
-@app.get("/historical", response_model=List[Candle])
-def get_historical_data(symbol: str, interval: str, from_date: str, to_date: str, auth: None = Depends(check_auth)):
-    instrument_token = get_instrument_token(symbol)
-    if not instrument_token: raise HTTPException(status_code=404, detail=f"Instrument not found for symbol: {symbol}")
     try:
-        records = kite.historical_data(instrument_token, from_date, to_date, interval)
+        quote_data = kite.quote(formatted_symbol)
+        instrument_quote = quote_data.get(formatted_symbol)
+        if not instrument_quote:
+            raise HTTPException(status_code=404, detail=f"Quote not found for symbol: {formatted_symbol}")
+
+        # The quote response from kite has 'tradingsymbol' which we can use
+        return QuoteResponse(symbol=instrument_quote['tradingsymbol'], **instrument_quote)
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+@app.get("/historical", response_model=List[Candle], dependencies=[Depends(verify_api_key)])
+def get_historical_data(symbol: str, interval: str, from_date: str, to_date: str, auth: None = Depends(check_kite_auth)):
+    """
+    Gets historical candle data.
+    'symbol' can be an instrument token (e.g., "12345") or a symbol string (e.g., "NSE:INFY").
+    'interval' can use shorthands like '5m', '1h', '1d'.
+    """
+    # Handle interval shorthands
+    interval_map = {
+        "5m": "5minute", "15m": "15minute", "1h": "60minute", "1d": "day"
+    }
+    final_interval = interval_map.get(interval, interval)
+
+    # Determine if symbol is a token or a string
+    if symbol.isdigit():
+        instrument_token = int(symbol)
+    else:
+        instrument_token = get_instrument_token(symbol)
+
+    if not instrument_token:
+        raise HTTPException(status_code=404, detail=f"Instrument not found for symbol/token: {symbol}")
+
+    try:
+        records = kite.historical_data(instrument_token, from_date, to_date, final_interval)
         return [Candle(time=r['date'], **r) for r in records]
-    except Exception as e: raise HTTPException(status_code=500, detail=str(e))
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
 
-@app.get("/instruments", response_model=InstrumentResponse)
-def search_instruments(query: str, auth: None = Depends(check_auth)):
+@app.get("/instruments", response_model=InstrumentResponse, dependencies=[Depends(verify_api_key)])
+def search_instruments(query: str, auth: None = Depends(check_kite_auth)):
     update_instrument_cache_if_needed()
     query = query.upper()
     for inst in instrument_cache["instruments"]:
@@ -156,8 +198,8 @@ def search_instruments(query: str, auth: None = Depends(check_auth)):
             return InstrumentResponse(tradingsymbol=inst['tradingsymbol'], token=inst['instrument_token'], lot_size=inst['lot_size'], exchange=inst['exchange'])
     raise HTTPException(status_code=404, detail=f"Instrument '{query}' not found.")
 
-@app.post("/target/calc", response_model=TargetCalcResponse)
-def calculate_target(request: TargetCalcRequest, auth: None = Depends(check_auth)):
+@app.post("/target/calc", response_model=TargetCalcResponse, dependencies=[Depends(verify_api_key)])
+def calculate_target(request: TargetCalcRequest, auth: None = Depends(check_kite_auth)):
     instrument_token = get_instrument_token(request.symbol)
     if not instrument_token: raise HTTPException(status_code=404, detail=f"Instrument not found: {request.symbol}")
     to_date = datetime.date.today(); from_date = to_date - datetime.timedelta(days=45)
@@ -182,8 +224,8 @@ def calculate_target(request: TargetCalcRequest, auth: None = Depends(check_auth
         return TargetCalcResponse(entry=request.entry_price, stop_loss=stop_loss, target1=target1, target2=round(target1 + (target_points / 2), 2), rr_ratio=rr_ratio)
     except Exception as e: raise HTTPException(status_code=500, detail=str(e))
 
-@app.post("/place_order", response_model=OrderResponse)
-def place_order(request: PlaceOrderRequest, background_tasks: BackgroundTasks, auth: None = Depends(check_auth)):
+@app.post("/place_order", response_model=OrderResponse, dependencies=[Depends(verify_api_key)])
+def place_order(request: PlaceOrderRequest, background_tasks: BackgroundTasks, auth: None = Depends(check_kite_auth)):
     try:
         exchange, tradingsymbol = request.symbol.split(':')
 
@@ -205,8 +247,8 @@ def place_order(request: PlaceOrderRequest, background_tasks: BackgroundTasks, a
         return OrderResponse(**response)
     except Exception as e: raise HTTPException(status_code=400, detail=str(e))
 
-@app.post("/modify_order", response_model=OrderResponse)
-def modify_order(request: ModifyOrderRequest, background_tasks: BackgroundTasks, auth: None = Depends(check_auth)):
+@app.post("/modify_order", response_model=OrderResponse, dependencies=[Depends(verify_api_key)])
+def modify_order(request: ModifyOrderRequest, background_tasks: BackgroundTasks, auth: None = Depends(check_kite_auth)):
     try:
         order_id = kite.modify_order(variety=kite.VARIETY_REGULAR, order_id=request.order_id, quantity=request.quantity,
                                      price=request.price, trigger_price=request.trigger_price, order_type=request.order_type)
@@ -215,8 +257,8 @@ def modify_order(request: ModifyOrderRequest, background_tasks: BackgroundTasks,
         return OrderResponse(**response)
     except Exception as e: raise HTTPException(status_code=400, detail=str(e))
 
-@app.post("/cancel_order", response_model=OrderResponse)
-def cancel_order(request: CancelOrderRequest, background_tasks: BackgroundTasks, auth: None = Depends(check_auth)):
+@app.post("/cancel_order", response_model=OrderResponse, dependencies=[Depends(verify_api_key)])
+def cancel_order(request: CancelOrderRequest, background_tasks: BackgroundTasks, auth: None = Depends(check_kite_auth)):
     try:
         order_id = kite.cancel_order(variety=kite.VARIETY_REGULAR, order_id=request.order_id)
         response = {"order_id": order_id, "status": "CANCELLED"}
@@ -224,21 +266,21 @@ def cancel_order(request: CancelOrderRequest, background_tasks: BackgroundTasks,
         return OrderResponse(**response)
     except Exception as e: raise HTTPException(status_code=400, detail=str(e))
 
-@app.get("/orders")
-def get_orders(auth: None = Depends(check_auth)):
+@app.get("/orders", dependencies=[Depends(verify_api_key)])
+def get_orders(auth: None = Depends(check_kite_auth)):
     try: return kite.orders()
     except Exception as e: raise HTTPException(status_code=500, detail=str(e))
 
-@app.get("/positions", response_model=List[Position])
-def get_positions(auth: None = Depends(check_auth)):
+@app.get("/positions", response_model=List[Position], dependencies=[Depends(verify_api_key)])
+def get_positions(auth: None = Depends(check_kite_auth)):
     try:
         net_positions = kite.positions().get('net', [])
         return [Position(symbol=p['tradingsymbol'], qty=p['quantity'], avg_price=p['average_price'], pnl=p['pnl'])
                 for p in net_positions if p.get('product') == 'MIS' and p.get('quantity') != 0]
     except Exception as e: raise HTTPException(status_code=500, detail=str(e))
 
-@app.post("/risk/check", response_model=RiskCheckResponse)
-def check_risk(request: RiskCheckRequest, auth: None = Depends(check_auth)):
+@app.post("/risk/check", response_model=RiskCheckResponse, dependencies=[Depends(verify_api_key)])
+def check_risk(request: RiskCheckRequest, auth: None = Depends(check_kite_auth)):
     cash_risk = (request.entry - request.stop_loss) * request.quantity
     margin_required = request.entry * request.quantity
     return RiskCheckResponse(cash_risk=round(cash_risk, 2), margin_required=round(margin_required, 2), rr_ratio=None)

--- a/render.yaml
+++ b/render.yaml
@@ -9,5 +9,7 @@ services:
         value: "YOUR_API_KEY_HERE"
       - key: KITE_API_SECRET
         value: "YOUR_API_SECRET_HERE"
+      - key: INTERNAL_API_KEY
+        value: "your_strong_secret_api_key_here" # Change this to a strong, random key
       - key: PYTHON_VERSION
         value: "3.10" # Or your desired python version


### PR DESCRIPTION
This commit adds three major improvements based on user feedback:

1.  Implements a new `x-api-key` header check for service-level authentication.
2.  Refactors the `/quote` endpoint to default to the NSE exchange for symbols without a prefix.
3.  Refactors the `/historical` endpoint to accept instrument tokens and interval shorthands.

This completes the current feature set and addresses recent bug reports.